### PR TITLE
Update to the latest bindgen version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,5 +14,5 @@ name = "libpg_query"
 path = "src/lib.rs"
 
 [build-dependencies]
-bindgen = "0.45.0"
+bindgen = "0.58.1"
 make-cmd = "0.1.0"


### PR DESCRIPTION
The older version of bindgen had a number of deps of its own that were out of
date and triggering complaints from cargo-audit in crates that consumed this
one.